### PR TITLE
Add jupyter-repo2docker

### DIFF
--- a/ansible/all.yml
+++ b/ansible/all.yml
@@ -2,3 +2,4 @@
 - import_playbook: docker.yml
 - import_playbook: users.yml
 - import_playbook: tljh.yml
+- import_playbook: images.yml

--- a/ansible/images.yml
+++ b/ansible/images.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  become: true
+  vars_files:
+    - vars/default.yml
+
+  tasks:
+    - name: Build the user images
+      shell: "{{ tljh_prefix }}/hub/bin/python3 -m tljh_plasmabio.build_images"

--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -17,14 +17,16 @@
         url: "{{ tljh_installer_url }}"
         dest: "{{ tljh_installer_dest }}"
 
+    - name: Upgrade the tljh-plasmabio plugin
+      shell: "{{ tljh_prefix }}/hub/bin/pip3 install --upgrade {{ tljh_plasmabio }}"
+      # ignore errors if this is a fresh install
+      ignore_errors: yes
+
     - name: Run the TLJH installer
       shell: "{{ ansible_python_interpreter }} {{ tljh_installer_dest }} --no-user-env --plugin {{ tljh_plasmabio }}"
       # TODO: remove when --no-user-env (or equivalent) is available
       environment:
         TLJH_BOOTSTRAP_PIP_SPEC: "{{ tljh_bootstrap_pip_spec }}"
-
-    - name: Upgrade the tljh-plasmabio plugin
-      shell: "{{ tljh_prefix }}/hub/bin/pip3 install --upgrade {{ tljh_plasmabio }}"
 
     - name: Restart JupyterHub
       systemd:

--- a/ansible/users.yml
+++ b/ansible/users.yml
@@ -5,6 +5,12 @@
     - vars/default.yml
 
   tasks:
+    - name: Add the jovyan user
+      user:
+        name: jovyan
+        uid: 1100
+        group: users
+
     - name: Add foo Test User
       user:
         name: foo

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ intersphinx_cache_limit = 90 # days
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
-html_theme = 'pandas_sphinx_theme'
+html_theme = 'pydata_sphinx_theme'
 
 html_logo = 'images/logo/logo.png'
 html_favicon = 'images/logo/logo.ico'

--- a/docs/configuration/environments.rst
+++ b/docs/configuration/environments.rst
@@ -1,0 +1,25 @@
+User Environments
+=================
+
+User environments are built as immutable Docker images. The Docker images bundle the dependencies, extensions,
+and predefined notebooks that should be available to all users.
+
+PlasmaBio uses `repo2docker <https://repo2docker.readthedocs.io>`_ to build the images on the server.
+
+Managing the user environments
+------------------------------
+
+Adding a new environment
+........................
+
+TODO
+
+Updating an environment
+.......................
+
+TODO
+
+Removing an environment
+.......................
+
+TODO

--- a/docs/configuration/environments.rst
+++ b/docs/configuration/environments.rst
@@ -6,6 +6,10 @@ and predefined notebooks that should be available to all users.
 
 PlasmaBio uses `repo2docker <https://repo2docker.readthedocs.io>`_ to build the images on the server.
 
+For now the user environments are static and built when running the ``images.yml`` Ansible playbook. This
+will be replaced by a UI within the JupyterHub interface and the steps to manage the environments will be
+described in the section below.
+
 Managing the user environments
 ------------------------------
 

--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -5,3 +5,4 @@ Configuration
    :maxdepth: 3
 
    persistence
+   environments

--- a/docs/configuration/persistence.rst
+++ b/docs/configuration/persistence.rst
@@ -1,32 +1,15 @@
 Data Persistence
 ================
 
-The user servers are started using JupyterHub's `SystemUserSpawner <https://github.com/jupyterhub/dockerspawner#systemuserspawner>`_.
+The user servers are started using JupyterHub's `DockerSpawner <https://github.com/jupyterhub/dockerspawner>`_.
 
-This spawner is based on the `DockerSpawner <https://github.com/jupyterhub/dockerspawner#dockerspawner>`_, but makes it possible
-to use the host users to start the notebook servers.
+Inside the container, the processes are started using the default ``jovyan`` user that is usually found in the regular
+Jupyter Docker images, on Binder and in the images built with ``repo2docker``.
 
-Concretely this means that the user inside the container will correspond to a real user that exists on the host.
-Processes will be started by that user, instead of the default ``jovyan`` user that is usually found in the regular
-Jupyter Docker images and on Binder.
-
-For example when the user ``alice`` starts her server, the list of processes looks like the following:
-
-.. code-block:: bash
-
-  alice@e4286692bcf4:~$ ps aux
-  USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-  root         1  0.8  0.0   4524   864 ?        Ss   10:37   0:00 tini -g -- start-notebook.sh --ip=0.0.0.0 --port=8888 --NotebookApp.default_url=/lab
-  root         6  0.0  0.0  51496  3788 ?        S    10:37   0:00 sudo -E -H -u alice PATH=/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin XDG_CACHE_HOME=/home/alice/.cache PYTHONPATH= jupyterhub-singleuser --ip=0.0.0.0 --port=8888 --NotebookApp.default
-  alice        31 4.6  1.8 465884 71480 ?        Sl   10:37   0:01 /opt/conda/bin/python /opt/conda/bin/jupyterhub-singleuser --ip=0.0.0.0 --port=8888 --NotebookApp.default_url=/lab
-  alice        66 1.7  0.0  20180  3804 pts/0    Ss   10:37   0:00 /bin/bash -l
-  alice        76 1.7  1.2 534132 49296 ?        Ssl  10:37   0:00 /opt/conda/bin/python -m ipykernel_launcher -f /home/alice/.local/share/jupyter/runtime/kernel-d324b5e1-619c-4056-a1b0-dcebd92c3ba3.json
-  alice        96 0.0  0.0  36076  3216 pts/0    R+   10:37   0:00 ps aux
-
-By default ``SystemUserSpawner`` mounts the user's home directory into the user container. This means that each notebook or file
+By default PlasmaBio mounts the ``/home/{username}/work`` directory on the host into the user container under ``/home/jovyan/work``. This means that each notebook or file
 will persist in the home directory for that user on the host machine.
 
-PlasmaBio uses the same default.
+The ``/home/jovyan/work`` will be located next to the other folders already in the user environment and packaged with ``repo2docker``.
 
 .. image:: ../images/configuration/persistence.png
    :alt: Mounting user's home directories

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=1.4, !=1.5.4
 sphinx_copybutton
-git+https://github.com/pandas-dev/pandas-sphinx-theme.git@master
+git+https://github.com/pandas-dev/pydata-sphinx-theme.git@master

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -1,23 +1,14 @@
-# This file is only used for local development
+"""
+This file is only used for local development
+and overrides some of the default values.
+"""
 
 import os
 
-from tljh_plasmabio import tljh_custom_jupyterhub_config
+from tljh_plasmabio import create_pre_spawn_hook, tljh_custom_jupyterhub_config
 
 tljh_custom_jupyterhub_config(c)
 
-# configure the volumes
-user_dir = os.path.join(os.getcwd(), "volumes/user/{username}")
-
-
-def create_user_volume(spawner):
-    """
-    A pre-spawn hook to create the user home directory with
-    the correct permissions when testing locally
-    """
-    username = spawner.user.name  # get the username
-    os.makedirs(user_dir.format(username=username), exist_ok=True)
-
-
-c.SystemUserSpawner.pre_spawn_hook = create_user_volume
-c.SystemUserSpawner.host_homedir_format_string = user_dir
+volumes_path = os.path.join(os.getcwd(), "volumes/user")
+c.DockerSpawner.volumes = {os.path.join(volumes_path, "{username}"): "/home/jovyan/work"}
+c.DockerSpawner.pre_spawn_hook = create_pre_spawn_hook(volumes_path)

--- a/tljh-plasmabio/setup.py
+++ b/tljh-plasmabio/setup.py
@@ -4,7 +4,10 @@ setup(
     name="tljh-plasmabio",
     version="0.0.1",
     entry_points={
-        "tljh": ["tljh_plasmabio = tljh_plasmabio"]
+        "tljh": ["tljh_plasmabio = tljh_plasmabio"],
+        "console_scripts": [
+            "build-images = tljh_plasmabio.build_images:main",
+        ]
     },
     packages=find_packages(),
     include_package_data=True,

--- a/tljh-plasmabio/setup.py
+++ b/tljh-plasmabio/setup.py
@@ -10,6 +10,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'dockerspawner',
-        'jupyter_client'
+        'jupyter_client',
+        'jupyter-repo2docker'
     ]
 )

--- a/tljh-plasmabio/tljh_plasmabio/__init__.py
+++ b/tljh-plasmabio/tljh_plasmabio/__init__.py
@@ -32,5 +32,6 @@ def tljh_custom_jupyterhub_config(c):
 def tljh_extra_hub_pip_packages():
     return [
         'dockerspawner',
-        'jupyter_client'
+        'jupyter_client',
+        'jupyter-repo2doocker'
     ]

--- a/tljh-plasmabio/tljh_plasmabio/__init__.py
+++ b/tljh-plasmabio/tljh_plasmabio/__init__.py
@@ -4,11 +4,7 @@ from jupyter_client.localinterfaces import public_ips
 from tljh.hooks import hookimpl
 
 
-# list of images to choose from when spawning a new server
-IMAGES = {
-    'python': 'jupyter/scipy-notebook',
-    'r': 'jupyter/r-notebook',
-}
+from .build_images import IMAGES
 
 
 @hookimpl
@@ -22,16 +18,15 @@ def tljh_custom_jupyterhub_config(c):
     # spawner
     # increase the timeout to be able to pull larger Docker images
     c.SystemUserSpawner.start_timeout = 120
-    c.SystemUserSpawner.image_whitelist = IMAGES
+    # TODO: make the image_whitelist a callable so it can pick up new images dynamically
+    c.SystemUserSpawner.image_whitelist = {k: k for k in IMAGES.keys()}
+    c.SystemUserSpawner.pull_policy = "Never"
     c.SystemUserSpawner.name_template = "{prefix}-{username}-{imagename}-{servername}"
-    c.SystemUserSpawner.default_url = '/lab'
+    c.SystemUserSpawner.default_url = "/lab"
+    c.SystemUserSpawner.cmd = ["jupyterhub-singleuser"]
     c.SystemUserSpawner.remove = True
 
 
 @hookimpl
 def tljh_extra_hub_pip_packages():
-    return [
-        'dockerspawner',
-        'jupyter_client',
-        'jupyter-repo2doocker'
-    ]
+    return ["dockerspawner", "jupyter_client", "jupyter-repo2doocker"]

--- a/tljh-plasmabio/tljh_plasmabio/__init__.py
+++ b/tljh-plasmabio/tljh_plasmabio/__init__.py
@@ -1,4 +1,8 @@
-from dockerspawner import SystemUserSpawner
+import os
+import pwd
+import shutil
+
+from dockerspawner import DockerSpawner
 from jupyterhub.auth import PAMAuthenticator
 from jupyter_client.localinterfaces import public_ips
 from tljh.hooks import hookimpl
@@ -7,26 +11,47 @@ from tljh.hooks import hookimpl
 from .build_images import IMAGES
 
 
+# TODO: make this configurable
+VOLUMES_PATH = "/volumes/users"
+
+
+# See: https://github.com/jupyterhub/jupyterhub/tree/master/examples/bootstrap-script#example-1---create-a-user-directory
+def create_pre_spawn_hook(base_path):
+    def create_dir_hook(spawner):
+        username = spawner.user.name
+        volume_path = os.path.join(base_path, username)
+        os.makedirs(volume_path, 0o755, exist_ok=True)
+        # use jovyan id (used when building the image with repo2docker)
+        shutil.chown(volume_path, user=1100, group="users")
+
+    return create_dir_hook
+
+
 @hookimpl
 def tljh_custom_jupyterhub_config(c):
     # hub
     c.JupyterHub.hub_ip = public_ips()[0]
     c.JupyterHub.allow_named_servers = True
+    c.JupyterHub.cleanup_servers = False
     c.JupyterHub.authenticator_class = PAMAuthenticator
-    c.JupyterHub.spawner_class = SystemUserSpawner
+    c.JupyterHub.spawner_class = DockerSpawner
 
     # spawner
     # increase the timeout to be able to pull larger Docker images
-    c.SystemUserSpawner.start_timeout = 120
+    c.DockerSpawner.start_timeout = 120
     # TODO: make the image_whitelist a callable so it can pick up new images dynamically
-    c.SystemUserSpawner.image_whitelist = {k: k for k in IMAGES.keys()}
-    c.SystemUserSpawner.pull_policy = "Never"
-    c.SystemUserSpawner.name_template = "{prefix}-{username}-{imagename}-{servername}"
-    c.SystemUserSpawner.default_url = "/lab"
-    c.SystemUserSpawner.cmd = ["jupyterhub-singleuser"]
-    c.SystemUserSpawner.remove = True
+    c.DockerSpawner.image_whitelist = {k: k for k in IMAGES.keys()}
+    c.DockerSpawner.pull_policy = "Never"
+    c.DockerSpawner.name_template = "{prefix}-{username}-{imagename}-{servername}"
+    c.DockerSpawner.default_url = "/lab"
+    c.DockerSpawner.cmd = ["jupyterhub-singleuser"]
+    c.DockerSpawner.volumes = {
+        os.path.join(VOLUMES_PATH, "{username}"): "/home/jovyan/work"
+    }
+    c.DockerSpawner.pre_spawn_hook = create_pre_spawn_hook(VOLUMES_PATH)
+    c.DockerSpawner.remove = True
 
 
 @hookimpl
 def tljh_extra_hub_pip_packages():
-    return ["dockerspawner", "jupyter_client", "jupyter-repo2doocker"]
+    return ["dockerspawner", "jupyter_client", "jupyter-repo2docker"]

--- a/tljh-plasmabio/tljh_plasmabio/build_images.py
+++ b/tljh-plasmabio/tljh_plasmabio/build_images.py
@@ -1,0 +1,51 @@
+import logging
+import sys
+import subprocess
+
+import docker
+
+logging.basicConfig(level=logging.INFO)
+
+
+# list of images to choose from when spawning a new server
+# TODO: make this dynamic and easier to edit
+IMAGES = {
+    "materials-example": "https://github.com/plasmabio/materials-example",
+    "python": "https://github.com/binder-examples/requirements",
+    "jupyter/scipy-notebook": "https://github.com/binder-examples/requirements",
+}
+
+
+def build_image(name, repo):
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "repo2docker",
+            "--ref",
+            "master",
+            "--user-name",
+            "jovyan",
+            "--user-id",
+            "1000",
+            "--no-run",
+            "--image-name",
+            name,
+            repo,
+        ]
+    )
+
+
+def main():
+    # prune stopped containers and dangling images
+    client = docker.from_env()
+    client.containers.prune()
+    client.images.prune()
+
+    for name, repo in IMAGES.items():
+        logging.info(f"Building image {name}")
+        build_image(name, repo)
+
+
+if __name__ == "__main__":
+    main()

--- a/tljh-plasmabio/tljh_plasmabio/build_images.py
+++ b/tljh-plasmabio/tljh_plasmabio/build_images.py
@@ -2,46 +2,39 @@ import logging
 import sys
 import subprocess
 
-import docker
-
 logging.basicConfig(level=logging.INFO)
 
 
 # list of images to choose from when spawning a new server
 # TODO: make this dynamic and easier to edit
 IMAGES = {
-    "materials-example": "https://github.com/plasmabio/materials-example",
-    "python": "https://github.com/binder-examples/requirements",
-    "jupyter/scipy-notebook": "https://github.com/binder-examples/requirements",
+    "python-template": "https://github.com/plasmabio/template-python",
+    "python-requirements": "https://github.com/binder-examples/requirements",
 }
 
 
 def build_image(name, repo):
+    ref = "master"
     subprocess.run(
         [
             sys.executable,
             "-m",
             "repo2docker",
             "--ref",
-            "master",
+            ref,
             "--user-name",
             "jovyan",
             "--user-id",
-            "1000",
+            "1100",
             "--no-run",
             "--image-name",
-            name,
+            f"{name}:latest",
             repo,
         ]
     )
 
 
 def main():
-    # prune stopped containers and dangling images
-    client = docker.from_env()
-    client.containers.prune()
-    client.images.prune()
-
     for name, repo in IMAGES.items():
         logging.info(f"Building image {name}")
         build_image(name, repo)


### PR DESCRIPTION
FIxes #25. 

Add `jupyter-repo2docker` to build the user images on the server.

- [x] Add / update the documentation to explain how the user environments are managed and built
