### PR TITLE
Cull servers after 1 hour of inactivity

### DIFF
--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -44,6 +44,10 @@
               email: {{ letsencrypt_email }}
               domains:
                 - {{ letsencrypt_domain }}
+          services:
+            cull:
+              timeout: 3600
+
 
     # TODO: do not restart the proxy each time, only on install
     - name: Reload the proxy

--- a/docs/configuration/cull.rst
+++ b/docs/configuration/cull.rst
@@ -1,0 +1,8 @@
+Culling idle servers
+====================
+
+PlasmaBio uses the `same defaults as The Littlest JupyterHub <http://tljh.jupyter.org/en/latest/topic/idle-culler.html#default-settings>`_
+for culling idle servers.
+
+It overrides the ``timeout`` value to ``3600``, which means that the user servers will be shut down if they have
+been idle for more than one hour.

--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -7,3 +7,4 @@ Configuration
    persistence
    environments
    resources
+   cull


### PR DESCRIPTION
Fixes #37.

![image](https://user-images.githubusercontent.com/591645/77186847-d278d780-6ad3-11ea-9707-eebf28bb41db.png)


- [x] Add / update the documentation to point to TLJH defaults
