### PR TITLE
Remove the default hosts file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ MANIFEST
 
 # the local user volumes used for testing
 volumes/
+
+# the Ansible hosts file
+ansible/hosts

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,5 +1,0 @@
-[servers]
-51.178.95.237
-
-[servers:vars]
-ansible_python_interpreter=/usr/bin/python3

--- a/docs/install/ansible.rst
+++ b/docs/install/ansible.rst
@@ -66,12 +66,26 @@ Check out the repository, and go to the ``plasmabio/ansible/`` directory:
     git clone https://github.com/plasmabio/plasmabio
     cd plasmabio/ansible
 
-Make sure the ``hosts`` file contains the correct IP and hostname for the server. For example:
+Create a ``hosts`` file with the following content:
 
 .. code-block:: text
 
     [servers]
     51.178.95.237
+
+    [servers:vars]
+    ansible_python_interpreter=/usr/bin/python3
+
+Replace the IP corresponds to your server. If you already defined the hostname (see :ref:`install/https`),
+you can also specify the domain name:
+
+.. code-block:: text
+
+    [servers]
+    dev.plasmabio.org
+
+    [servers:vars]
+    ansible_python_interpreter=/usr/bin/python3
 
 Then run the following command after replacing ``<user>`` by your user on the remote machine:
 

--- a/docs/install/https.rst
+++ b/docs/install/https.rst
@@ -1,3 +1,5 @@
+.. _install/https:
+
 HTTPS
 =====
 


### PR DESCRIPTION
Fixes #31.

Users are responsible for creating their own `hosts` file.

- [x] Add / update the documentation
