### PR TITLE
Add an opt-in Ansible task to disable HTTPS

### DIFF
--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -48,10 +48,15 @@
             cull:
               timeout: 3600
 
+    # Special task to disable HTTPS only when the --no-https flag is specified
+    - name: Disable HTTPS
+      shell: "{{ tljh_prefix }}/hub/bin/python3 -m tljh.config set https.enabled false"
+      tags: [ never, no-https ]
+
 
     # TODO: do not restart the proxy each time, only on install
     - name: Reload the proxy
-      shell: "{{ tljh_prefix }}/hub/bin/python3 -m tljh.config reload proxy"
+      shell: "{{ tljh_prefix }}/hub/bin/python3 -m tljh.config reload"
 
     # Pull the repo2docker image to build user images
     - name: Pull jupyter/repo2docker

--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -49,6 +49,7 @@
               timeout: 3600
 
     # Special task to disable HTTPS only when the --no-https flag is specified
+    # The never tag is a special tag, see: https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html#special-tags
     - name: Disable HTTPS
       shell: "{{ tljh_prefix }}/hub/bin/python3 -m tljh.config set https.enabled false"
       tags: [ never, no-https ]

--- a/docs/install/https.rst
+++ b/docs/install/https.rst
@@ -27,3 +27,20 @@ This is typically done by logging in to the registrar website and adding a new e
 
 You can refer to the `documentation for The Littlest JupyterHub on how to enable HTTPS <http://tljh.jupyter.org/en/latest/howto/admin/https.html#enable-https>`_
 for more details.
+
+
+Deploying without HTTPS
+-----------------------
+
+.. warning::
+
+    **We do not recommend deploying JupyterHub without HTTPS for production use.**
+    However in some situations it can be handy to do so, for example when testing the setup.
+
+The next section describes how to use the Ansible playbooks to provision the machine: :ref:`install/ansible`.
+
+If you want to disable HTTPS, add ``--tags "all,no-https"`` at the end of the Ansible commands. For example:
+
+.. code-block:: bash
+
+    ansible-playbook -i hosts tljh.yml -u ubuntu --tags "all,no-https"


### PR DESCRIPTION
Fixes #76.

This explicit task makes it possible to disable HTTPS, but the `--no-https` has to be explicitely provided:

```bash
ansible-playbook -i hosts all.yml -u ubuntu --tags "all,no-https"
```

- [x] Add / update the documentation
