### PR TITLE
Add the environment service to the list of services

### DIFF
--- a/tljh-plasmabio/tljh_plasmabio/__init__.py
+++ b/tljh-plasmabio/tljh_plasmabio/__init__.py
@@ -108,7 +108,7 @@ def tljh_custom_jupyterhub_config(c):
     c.DockerSpawner.options_form = options_form
 
     # register the service to manage the user images
-    c.JupyterHub.services = [
+    c.JupyterHub.services += [
         {
             "name": "environments",
             "admin": True,


### PR DESCRIPTION
It turns out that the TLJH cull service was not enabled because the Plasmabio plugin would overwrite the list of services by assigning with `=`.

- [x] ~Add / update the documentation~
