### PR TITLE
Use the all.yml playbook in the no-https command

### DIFF
--- a/docs/install/https.rst
+++ b/docs/install/https.rst
@@ -43,4 +43,4 @@ If you want to disable HTTPS, add ``--tags "all,no-https"`` at the end of the An
 
 .. code-block:: bash
 
-    ansible-playbook -i hosts tljh.yml -u ubuntu --tags "all,no-https"
+    ansible-playbook all.yml -i hosts -u ubuntu --tags "all,no-https"


### PR DESCRIPTION
Fixes the documentation to use the `all.yml` playbook in the "Deploying without HTTPS" section.

- [x] Add / update the documentation
