### PR TITLE
Add https.yml playbook to enable HTTPS

### DIFF
--- a/ansible/https.yml
+++ b/ansible/https.yml
@@ -9,7 +9,7 @@
     # Enable Automatic HTTPS with Let's Encrypt
     - name: Enable HTTPS
       shell: |
-        tljh-config set https.enabled false
+        tljh-config set https.enabled true
         tljh-config set https.letsencrypt.email {{ letsencrypt_email }}
         tljh-config add-item https.letsencrypt.domains {{ letsencrypt_domain }}
 

--- a/ansible/https.yml
+++ b/ansible/https.yml
@@ -1,0 +1,17 @@
+---
+- hosts: all
+  become: true
+  vars_files:
+    - vars/default.yml
+
+  tasks:
+
+    # Enable Automatic HTTPS with Let's Encrypt
+    - name: Enable HTTPS
+      shell: |
+        tljh-config set https.enabled false
+        tljh-config set https.letsencrypt.email {{ letsencrypt_email }}
+        tljh-config add-item https.letsencrypt.domains {{ letsencrypt_domain }}
+
+    - name: Reload the proxy
+      shell: "tljh-config reload proxy"

--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -28,33 +28,11 @@
       environment:
         TLJH_BOOTSTRAP_PIP_SPEC: "{{ tljh_bootstrap_pip_spec }}"
 
-    - name: Copy the config
-      copy:
-        dest: "{{ tljh_prefix }}/config/config.yaml"
-        content: |
-          https:
-            enabled: true
-            letsencrypt:
-              email: {{ letsencrypt_email }}
-              domains:
-                - {{ letsencrypt_domain }}
-          services:
-            cull:
-              timeout: 3600
+    - name: Set the idle culler timeout to 1 hour
+      shell: "tljh-config set services.cull.timeout 3600"
 
     - name: Reload the hub
-      shell: "{{ tljh_prefix }}/hub/bin/python3 -m tljh.config reload hub"
-
-    # Special task to disable HTTPS only when the --no-https flag is specified
-    # The never tag is a special tag, see: https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html#special-tags
-    - name: Disable HTTPS
-      shell: "{{ tljh_prefix }}/hub/bin/python3 -m tljh.config set https.enabled false"
-      tags: [ never, no-https ]
-
-
-    # TODO: do not restart the proxy each time, only on install
-    - name: Reload the proxy
-      shell: "{{ tljh_prefix }}/hub/bin/python3 -m tljh.config reload proxy"
+      shell: "tljh-config reload hub"
 
     # Pull the repo2docker image to build user images
     - name: Pull jupyter/repo2docker

--- a/docs/install/https.rst
+++ b/docs/install/https.rst
@@ -3,7 +3,16 @@
 HTTPS
 =====
 
-HTTPS is **enabled by default** when using the Ansible playbooks, see :ref:`install/ansible`.
+.. warning::
+
+    HTTPS is **not** enabled by default.
+
+    **We do not recommend deploying JupyterHub without HTTPS for production use.**
+
+    However in some situations it can be handy to do so, for example when testing the setup.
+
+Enable HTTPS
+------------
 
 Support for HTTPS is handled automatically thanks to `Let's Encrypt <https://letsencrypt.org>`_, which also
 handles the renewal of the certificates when they are about to expire.
@@ -15,7 +24,17 @@ In the Ansible playbook, the Let's Encrypt configuration is defined in ``ansible
     letsencrypt_email: contact@plasmabio.org
     letsencrypt_domain: dev.plasmabio.org
 
-If you decide to change the domain and email later, modify ``ansible/vars/default.yml`` and rerun the playbook.
+Modify these values to the ones you want to use.
+
+Then, run the ``https.yml`` playbook:
+
+.. code-block:: bash
+
+    ansible-playbook https.yml -i hosts -u ubuntu
+
+This will reload the proxy to take the changes into account.
+
+It might take a few minutes for the certificates to be setup and the changes to take effect.
 
 How to make the domain point to the IP of the server
 ----------------------------------------------------
@@ -28,19 +47,12 @@ This is typically done by logging in to the registrar website and adding a new e
 You can refer to the `documentation for The Littlest JupyterHub on how to enable HTTPS <http://tljh.jupyter.org/en/latest/howto/admin/https.html#enable-https>`_
 for more details.
 
+Manual HTTPS
+------------
 
-Deploying without HTTPS
------------------------
+To use an existing SSL key and certificate, you can refer to the
+`Manual HTTPS with existing key and certificate <http://tljh.jupyter.org/en/latest/howto/admin/https.html#manual-https-with-existing-key-and-certificate>`_
+documentation for TLJH.
 
-.. warning::
-
-    **We do not recommend deploying JupyterHub without HTTPS for production use.**
-    However in some situations it can be handy to do so, for example when testing the setup.
-
-The next section describes how to use the Ansible playbooks to provision the machine: :ref:`install/ansible`.
-
-If you want to disable HTTPS, add ``--tags "all,no-https"`` at the end of the Ansible commands. For example:
-
-.. code-block:: bash
-
-    ansible-playbook all.yml -i hosts -u ubuntu --tags "all,no-https"
+This can also be integrated in the ``https.yml`` playbook by replacing the ``tljh-config`` commands to the ones mentioned
+in the documentation.

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -7,5 +7,5 @@ This guide will walk you through the steps to install PlasmaBio on your own serv
    :maxdepth: 3
 
    requirements
-   https
    ansible
+   https


### PR DESCRIPTION
Fixes #88.
Fixes #89.

This actually disables HTTPS by default.

The main reason for this change is to reduce friction when trying out the deployment, to not have to setup the DNS. This is useful for temporary tests.

However production setups should (must) still enable HTTPS.

- [x] Add / update the documentation
