### PR TITLE
Set step and min values to 1 for the mem and cpu limits

### DIFF
--- a/tljh-plasmabio/tljh_plasmabio/templates/images.html
+++ b/tljh-plasmabio/tljh_plasmabio/templates/images.html
@@ -102,13 +102,13 @@
     <div class="form-group">
       <label for="memory" class="col-sm-4 control-label">Memory Limit (GB)</label>
       <div class="col-sm-8">
-        <input type="number" step="1" class="form-control memory-input" id="memory" placeholder="2"/>
+        <input type="number" step="1" min="1" class="form-control memory-input" id="memory" placeholder="2"/>
       </div>
     </div>
     <div class="form-group">
       <label for="cpu" class="col-sm-4 control-label">CPU Limit</label>
       <div class="col-sm-8">
-        <input type="number" step="0.5" class="form-control cpu-input" id="cpu" placeholder="2"/>
+        <input type="number" step="1" min="1" class="form-control cpu-input" id="cpu" placeholder="2"/>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #99.

Keeping the possibility to enter decimal values for users who really want to, or when running on a small server.

![limit-min-step-values](https://user-images.githubusercontent.com/591645/79346751-03adc180-7f33-11ea-8141-8a45835b28ab.gif)

- [x] ~Add / update the documentation~
