### PR TITLE
Add playbook to add admin users

### DIFF
--- a/ansible/admins.yml
+++ b/ansible/admins.yml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+  become: true
+  vars_files:
+    - vars/default.yml
+
+  tasks:
+
+    # Add JupyterHub admins
+    - name: Add admin users
+      shell: tljh-config add-item users.admin {{ item }}
+      loop: "{{ admins }}"
+
+    - name: Reload the hub
+      shell: "tljh-config reload hub"

--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -23,7 +23,7 @@
       ignore_errors: yes
 
     - name: Run the TLJH installer
-      shell: "{{ ansible_python_interpreter }} {{ tljh_installer_dest }} --no-user-env --plugin {{ tljh_plasmabio }} --admin foo"
+      shell: "{{ ansible_python_interpreter }} {{ tljh_installer_dest }} --no-user-env --plugin {{ tljh_plasmabio }}"
       # TODO: remove when --no-user-env (or equivalent) is available
       environment:
         TLJH_BOOTSTRAP_PIP_SPEC: "{{ tljh_bootstrap_pip_spec }}"

--- a/docs/environments/index.rst
+++ b/docs/environments/index.rst
@@ -13,6 +13,10 @@ Environments can be managed by admin users by clicking on ``Services -> environm
    :width: 50%
    :align: center
 
+.. note::
+
+  The user must be an **admin** to be able to access and manage the list of environments.
+
 
 The page will show the list of environments currently available:
 

--- a/docs/install/admins.rst
+++ b/docs/install/admins.rst
@@ -1,0 +1,18 @@
+.. _install/admins:
+
+Admin Users
+===========
+
+By default the ``site.yml`` playbook does not add admin users to JupyterHub.
+
+New admin users can be added by running the ``admins.yml`` playbook:
+
+.. code-block:: bash
+
+    ansible-playbook admins.yml -i hosts -u ubuntu --extra-vars '{"admins": ["foo", "bar"]}'
+
+This playbook processes the list of users specified via the ``--extra-vars`` command and add them as admin one at a time.
+
+Alternatively it is also possible to use the ``tljh-config`` command on the server directly.
+Please refer to `the Littlest JupyterHub documentation <http://tljh.jupyter.org/en/latest/howto/admin/admin-users.html#adding-admin-users-from-the-command-line>`_
+for more info.

--- a/docs/install/ansible.rst
+++ b/docs/install/ansible.rst
@@ -184,7 +184,6 @@ and update The Littlest JupyterHub):
 For more in-depth details about the Ansible playbook, check out the
 `official documentation <https://docs.ansible.com/ansible/latest/user_guide/playbooks.html>`_.
 
-
 List of available playbooks
 ---------------------------
 
@@ -194,5 +193,7 @@ The Ansible playbooks are located in the ``ansible/`` directory:
 - ``utils.yml``: install extra system packages useful for debugging and system administration
 - ``users.yml``: create the tests users on the host
 - ``tljh.yml``: install TLJH and the PlasmaBio TLJH plugin
+- ``admins.yml``: add admin users to JupyterHub
 - ``https.yml``: enable HTTPS for TLJH
-- ``site.yml``: the main playbook that references all the other playbooks
+- ``uninstall.yml``: uninstall TLJH only
+- ``site.yml``: the main playbook that references some of the other playbooks

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -9,5 +9,6 @@ This guide will walk you through the steps to install PlasmaBio on your own serv
    requirements
    ansible
    https
+   admins
    upgrade
    uninstall


### PR DESCRIPTION
Fixes #109 

Usage: 

```bash
ansible-playbook admins.yml -i hosts -u ubuntu --extra-vars '{"admins": ["foo", bar"]}'
```

Unfortunately this task is not idempotent. `tljh-config add-item` will append the username to the list of admins even if it's already there (which makes sense for lists).

Ideally TLJH would support using `tljh-config set users.admin ["foo", "bar"]` with a list as a value, which would replace the whole list at once.

- [x] Add / update the documentation
