### PR TITLE
Add a check before updating the TLJH plugin

### DIFF
--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -17,10 +17,14 @@
         url: "{{ tljh_installer_url }}"
         dest: "{{ tljh_installer_dest }}"
 
-    - name: Upgrade the tljh-plasmabio plugin
+    - name: Check if the tljh-plasmabio is already installed
+      shell: "{{ tljh_prefix }}/hub/bin/python3 -c 'import tljh_plasmabio'"
+      register: tljh_plasmabio_installed
+      failed_when: tljh_plasmabio_installed.rc != 0 or tljh_plasmabio_installed.rc != 1
+
+    - name: Upgrade the tljh-plasmabio plugin first if it is already installed
       shell: "{{ tljh_prefix }}/hub/bin/pip3 install --upgrade {{ tljh_plasmabio }}"
-      # ignore errors if this is a fresh install
-      ignore_errors: yes
+      when: tljh_plasmabio_installed.rc == 0
 
     - name: Run the TLJH installer
       shell: "{{ ansible_python_interpreter }} {{ tljh_installer_dest }} --no-user-env --plugin {{ tljh_plasmabio }}"

--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -18,9 +18,10 @@
         dest: "{{ tljh_installer_dest }}"
 
     - name: Check if the tljh-plasmabio is already installed
-      shell: "{{ tljh_prefix }}/hub/bin/python3 -c 'import tljh_plasmabio'"
+      command: "{{ tljh_prefix }}/hub/bin/python3 -c 'import tljh_plasmabio'"
       register: tljh_plasmabio_installed
-      failed_when: tljh_plasmabio_installed.rc != 0 or tljh_plasmabio_installed.rc != 1
+      failed_when: tljh_plasmabio_installed.rc > 2
+      changed_when: False
 
     - name: Upgrade the tljh-plasmabio plugin first if it is already installed
       shell: "{{ tljh_prefix }}/hub/bin/pip3 install --upgrade {{ tljh_plasmabio }}"


### PR DESCRIPTION
Fixes #53 

Add a check before updating the TLJH plugin in the `tljh.yml` playbook.

This also makes it easier to catch potential errors during the update of the plugin instead of ignoring them.

On a fresh run the output will look like this:

```
TASK [Check if the tljh-plasmabio is already installed] *****************************************************
ok: [test.plasmabio.org]

TASK [Upgrade the tljh-plasmabio plugin first if it is already installed] ***********************************
skipping: [test.plasmabio.org]

TASK [Run the TLJH installer] *******************************************************************************
```

For an update / rerun:

```
TASK [Check if the tljh-plasmabio is already installed] *****************************************************
ok: [test.plasmabio.org]

TASK [Upgrade the tljh-plasmabio plugin first if it is already installed] ***********************************
changed: [test.plasmabio.org]
```

- [x] ~Add / update the documentation~
