### PR TITLE
Add section about pulling repo2docker in contributing docs

### DIFF
--- a/docs/contributing/local.rst
+++ b/docs/contributing/local.rst
@@ -41,6 +41,15 @@ Install the development requirements
   # Install (https://github.com/jupyterhub/configurable-http-proxy)
   npm -g install configurable-http-proxy
 
+Pull the repo2docker Docker image
+---------------------------------
+
+User environments are built with ``repo2docker`` running in a Docker container. To pull the Docker image:
+
+.. code-block:: bash
+
+  docker pull jupyter/repo2docker
+
 Run
 ---
 


### PR DESCRIPTION
Add a section about pulling `jupyter/repo2docker` in the contributing documentation.

It is needed to build images locally.

- [x] Add / update the documentation
