### PR TITLE
Unset HTTPS and admins before adding the new items

### DIFF
--- a/ansible/admins.yml
+++ b/ansible/admins.yml
@@ -6,7 +6,9 @@
 
   tasks:
 
-    # Add JupyterHub admins
+    - name: Reset the list of admin users to avoid duplicates
+      shell: tljh-config unset users.admin
+
     - name: Add admin users
       shell: tljh-config add-item users.admin {{ item }}
       loop: "{{ admins }}"

--- a/ansible/https.yml
+++ b/ansible/https.yml
@@ -9,6 +9,7 @@
       shell: |
         tljh-config set https.enabled true
         tljh-config set https.letsencrypt.email {{ letsencrypt_email }}
+        tljh-config unset https.letsencrypt.domains
         tljh-config add-item https.letsencrypt.domains {{ name_server }}
 
     - name: Reload the proxy

--- a/docs/install/admins.rst
+++ b/docs/install/admins.rst
@@ -13,6 +13,10 @@ New admin users can be added by running the ``admins.yml`` playbook:
 
 This playbook processes the list of users specified via the ``--extra-vars`` command and add them as admin one at a time.
 
+.. warning::
+
+    The list passed via the ``--extra-vars`` parameter overrides the existing list of admins.
+
 Alternatively it is also possible to use the ``tljh-config`` command on the server directly.
 Please refer to `the Littlest JupyterHub documentation <http://tljh.jupyter.org/en/latest/howto/admin/admin-users.html#adding-admin-users-from-the-command-line>`_
 for more info.


### PR DESCRIPTION
Fixes #112.

This makes it possible to re-run the playbooks multiple times without adding new entries to the list.

Instructions to run the playbooks are still the same as before.

- [x] Add / update the documentation
