### PR TITLE
Add section about user creation to the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ MANIFEST
 # the local user volumes used for testing
 volumes/
 
-# the Ansible hosts file
+# the Ansible file
 ansible/hosts
+ansible/users-config.yml

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,6 +1,5 @@
 ---
 - import_playbook: docker.yml
 - import_playbook: utils.yml
-- import_playbook: users.yml
 - import_playbook: cockpit.yml
 - import_playbook: tljh.yml

--- a/ansible/users.yml
+++ b/ansible/users.yml
@@ -1,18 +1,11 @@
 ---
 - hosts: all
   become: true
-  vars_files:
-    - vars/default.yml
 
   tasks:
-    - name: Add foo Test User
+    - name: Add users
       user:
-        name: foo
-        password: $6$CnqUc/Ayp94RjVrl$ka.yRuhJ.vzE9oZJNi5AvmzBv/1J2fdGJuR.xCE2dwAAhOJxDIwBLjxLhXUKUjhJKgocL5ulERrJN3A/odQBv/
+        name: "{{ item.name }}"
+        password: "{{ item.password }}"
         shell: /bin/bash
-
-    - name: Add bar Test User
-      user:
-        name: bar
-        password: $6$GtGG1/ZeJ4QrA9.R$SmnuofrF9D8BfYGpHwHSJ8wizLoqHfIJc8JQNROR7mM8/Edu8SlEPCxAxQ3y6uyxqNS8NHOgVc9v3gM5c1GOO1
-        shell: /bin/bash
+      loop: "{{ users }}"

--- a/ansible/users.yml
+++ b/ansible/users.yml
@@ -6,6 +6,6 @@
     - name: Add users
       user:
         name: "{{ item.name }}"
-        password: "{{ item.password }}"
+        password: "{{ item.password | password_hash('sha512') }}"
         shell: /bin/bash
       loop: "{{ users }}"

--- a/docs/install/admins.rst
+++ b/docs/install/admins.rst
@@ -1,7 +1,7 @@
 .. _install/admins:
 
-Admin Users
-===========
+Adding Admin Users to JupyterHub
+================================
 
 By default the ``site.yml`` playbook does not add admin users to JupyterHub.
 

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -9,6 +9,7 @@ This guide will walk you through the steps to install PlasmaBio on your own serv
    requirements
    ansible
    https
+   users
    admins
    upgrade
    uninstall

--- a/docs/install/users.rst
+++ b/docs/install/users.rst
@@ -9,6 +9,9 @@ Creating Users on the host
   This step is optional because in some scenarios users might already exist on the host machine
   and don't need to be created.
 
+Using the users playbook
+------------------------
+
 The ``ansible/`` directory contains a ``users.yml`` playbook that makes it easier to create new users on the host in batches.
 
 First you need to create a new ``users-config.yml`` with the following content:

--- a/docs/install/users.rst
+++ b/docs/install/users.rst
@@ -1,0 +1,35 @@
+.. _install/users:
+
+Creating Users on the host
+==========================
+
+.. note::
+  By default the ``site.yml`` playbook does not create any users on the host machine.
+
+  This step is optional because in some scenarios users might already exist on the host machine
+  and don't need to be created.
+
+The ``ansible/`` directory contains a ``users.yml`` playbook that makes it easier to create new users on the host in batches.
+
+First you need to create a new ``users-config.yml`` with the following content:
+
+.. code-block:: yaml
+
+    users:
+      - name: foo
+        password: HASHED_PASSWORD
+
+      - name: bar
+        password: HASHED_PASSWORD
+
+Replace the ``name`` and ``password`` entries by the real values.
+
+``password`` should correspond to the encrypted value of the user password. Please refer to the
+`Ansible Documentation <http://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module>`_
+to learn how to generate the encrypted passwords.
+
+When the user file is ready, execute the ``users.yml`` playbook with the following command:
+
+.. code-block:: bash
+
+    ansible-playbook users.yml -i host -u ubuntu -e @users-config.yml

--- a/docs/install/users.rst
+++ b/docs/install/users.rst
@@ -17,14 +17,16 @@ First you need to create a new ``users-config.yml`` with the following content:
 
     users:
       - name: foo
-        password: HASHED_PASSWORD
+        password: PLAIN_TEXT_PASSWORD
 
       - name: bar
-        password: HASHED_PASSWORD
+        password: PLAIN_TEXT_PASSWORD
 
 Replace the ``name`` and ``password`` entries by the real values.
 
-``password`` should correspond to the encrypted value of the user password. Please refer to the
+``password`` should correspond to the plain text value of the user password.
+
+For more info about password hashing, please refer to the
 `Ansible Documentation <http://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module>`_
 to learn how to generate the encrypted passwords.
 
@@ -33,3 +35,19 @@ When the user file is ready, execute the ``users.yml`` playbook with the followi
 .. code-block:: bash
 
     ansible-playbook users.yml -i host -u ubuntu -e @users-config.yml
+
+Handling secrets
+----------------
+
+.. warning::
+
+  Passwords are sensitive data. The ``users.yml`` playbook mentioned in the previous section
+  automatically encrypts the password from a plain text file.
+
+  For production use, you should consider protecting the passwords using the
+  `Ansible Vault <https://docs.ansible.com/ansible/latest/user_guide/playbooks_vault.html#playbooks-vault>`_.
+
+This ``users.yml`` playbook is mostly provided as a convenience script to quickly bootstrap the host machine with
+a predefined set of users.
+
+You are free to choose a different approach for managing users that suits your needs.


### PR DESCRIPTION
Fixes #120. 

Add documentation to create users on the host using an Ansible playbook.

- [x] Add / update the documentation
