### PR TITLE
Update the documentation to install cockpit manually

### DIFF
--- a/ansible/cockpit.yml
+++ b/ansible/cockpit.yml
@@ -22,3 +22,13 @@
 
           # SSL termination is done on the Traefik proxy
           AllowUnencrypted=true
+
+    - name: Ensure cockpit is running
+      systemd:
+        name: cockpit
+        state: started
+        daemon_reload: yes
+
+    # Restart JupyterHub to add the cockpit service
+    - name: Restart the hub
+      shell: "tljh-config reload hub"

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,5 +1,4 @@
 ---
 - import_playbook: docker.yml
 - import_playbook: utils.yml
-- import_playbook: cockpit.yml
 - import_playbook: tljh.yml

--- a/docs/configuration/monitoring.rst
+++ b/docs/configuration/monitoring.rst
@@ -5,17 +5,26 @@ Monitoring
 
   HTTPS must be enabled to be able to access Cockpit. Refer to :ref:`install/https` for more info.
 
-Cockpit
--------
+Installing Cockpit
+------------------
 
-The ``site.yml`` playbook installs ``cockpit`` by default as a monitoring tool for the server.
+``cockpit`` is not installed by default as a monitoring tool for the server.
 
-Additionally the PlasmaBio TLJH plugin registers ``cockpit`` as a JupyterHub service. This means that
+First make sure HTTPS is enabled and the ``name_server`` variable is specified in the ``hosts`` file.
+See :ref:`install/https` for more info.
+
+Then execute the ``cockpit.yml`` playbook:
+
+.. code-block:: bash
+
+    ansible-playbook cockpit.yml -i hosts -u ubuntu
+
+The PlasmaBio TLJH plugin registers ``cockpit`` as a JupyterHub service. This means that
 Cockpit is accessible to JupyterHub admin users via the JupyterHub interface:
 
 .. image:: ../images/configuration/cockpit-navbar.png
    :alt: Accessing cockpit from the nav bar
-   :width: 50%
+   :width: 100%
    :align: center
 
 Users will be asked to login with their system credentials. They can then access the Cockpit dashboard:


### PR DESCRIPTION
Fixes #137. 

However since Cockpit is added to the list of services in the TLJH plugin, it would probably make sense to have it installed by default:

https://github.com/plasmabio/plasmabio/blob/1ac4deb897ae5d76099afc072bf7092954de9ef9/tljh-plasmabio/tljh_plasmabio/__init__.py#L131

Otherwise the plugin could check whether the cockpit service is active before adding itself to the list of the service, using TLJH's [check_service_active](https://github.com/jupyterhub/the-littlest-jupyterhub/blob/01ba34857dd4e316d839034ae2b3cc400b929964/tljh/systemd.py#L99).

- [x] Add / update the documentation
