### PR TITLE
Update to TLJH 2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
     - name: Install node
       uses: actions/setup-node@v4
       with:
-       node-version: '18.x'
+       node-version: '22.x'
     - name: Install configurable-http-proxy
       run: npm -g install configurable-http-proxy
     - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ ansible/*.csv
 
 # local TLJH config used for testing
 config.yaml
+
+# tljh-repo2docker
+*.sqlite

--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -44,6 +44,7 @@
     # Pull the repo2docker image to build user images
     - name: Pull the repo2docker Docker image
       docker_image:
-        name: quay.io/jupyterhub/repo2docker
-        tag: main
+        name: "{{ repo2docker_docker_name }}"
+        tag: "{{ repo2docker_docker_tag }}"
         source: pull
+        force_source: yes

--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -26,11 +26,8 @@
 
     - name: Run the TLJH installer
       shell: |
-        {{ ansible_python_interpreter }} {{ tljh_installer_dest }} --no-user-env \
+        {{ ansible_python_interpreter }} {{ tljh_installer_dest }} \
           --plugin {{ tljh_plasma }} {{ tljh_repo2docker }}
-      # TODO: remove when --no-user-env (or equivalent) is available
-      environment:
-        TLJH_BOOTSTRAP_PIP_SPEC: "{{ tljh_bootstrap_pip_spec }}"
 
     - name: Set the idle culler timeout to 1 hour
       shell: "tljh-config set services.cull.timeout 3600"

--- a/ansible/tljh.yml
+++ b/ansible/tljh.yml
@@ -28,6 +28,7 @@
       shell: |
         {{ ansible_python_interpreter }} {{ tljh_installer_dest }} \
           --plugin {{ tljh_plasma }} {{ tljh_repo2docker }}
+          --version {{ tljh_version }}
 
     - name: Set the idle culler timeout to 1 hour
       shell: "tljh-config set services.cull.timeout 3600"

--- a/ansible/vars/default.yml
+++ b/ansible/vars/default.yml
@@ -8,6 +8,6 @@ tljh_installer_url: https://tljh.jupyter.org/bootstrap.py
 tljh_version: 2.0.0
 
 repo2docker_docker_name: quay.io/jupyterhub/repo2docker
-repo2docker_docker_tag: 2023.06.0-41.g57d229e
+repo2docker_docker_tag: 2024.07.0-166.ge795060
 
 ...

--- a/ansible/vars/default.yml
+++ b/ansible/vars/default.yml
@@ -7,4 +7,7 @@ tljh_prefix: /opt/tljh
 tljh_installer_url: https://tljh.jupyter.org/bootstrap.py
 tljh_version: 2.0.0
 
+repo2docker_docker_name: quay.io/jupyterhub/repo2docker
+repo2docker_docker_tag: 2023.06.0-41.g57d229e
+
 ...

--- a/ansible/vars/default.yml
+++ b/ansible/vars/default.yml
@@ -1,7 +1,7 @@
 ---
 
 tljh_plasma: git+https://github.com/plasmabio/plasma@master#"egg=tljh-plasma&subdirectory=tljh-plasma"
-tljh_repo2docker: tljh-repo2docker==2.0.0
+tljh_repo2docker: tljh-repo2docker==3.0.0a0
 tljh_installer_dest: /srv/tljh-installer.py
 tljh_prefix: /opt/tljh
 tljh_installer_url: https://tljh.jupyter.org/bootstrap.py

--- a/ansible/vars/default.yml
+++ b/ansible/vars/default.yml
@@ -1,10 +1,10 @@
 ---
 
 tljh_plasma: git+https://github.com/plasmabio/plasma@master#"egg=tljh-plasma&subdirectory=tljh-plasma"
-tljh_repo2docker: tljh-repo2docker==1.0.1
+tljh_repo2docker: tljh-repo2docker==2.0.0
 tljh_installer_dest: /srv/tljh-installer.py
 tljh_prefix: /opt/tljh
 tljh_installer_url: https://tljh.jupyter.org/bootstrap.py
-tljh_version: 1.0.0
+tljh_version: 2.0.0
 
 ...

--- a/ansible/vars/default.yml
+++ b/ansible/vars/default.yml
@@ -5,5 +5,6 @@ tljh_repo2docker: tljh-repo2docker==1.0.1
 tljh_installer_dest: /srv/tljh-installer.py
 tljh_prefix: /opt/tljh
 tljh_installer_url: https://tljh.jupyter.org/bootstrap.py
+tljh_version: 1.0.0
 
 ...

--- a/ansible/vars/default.yml
+++ b/ansible/vars/default.yml
@@ -4,9 +4,6 @@ tljh_plasma: git+https://github.com/plasmabio/plasma@master#"egg=tljh-plasma&sub
 tljh_repo2docker: tljh-repo2docker==1.0.1
 tljh_installer_dest: /srv/tljh-installer.py
 tljh_prefix: /opt/tljh
-# TODO: update to upstream TLJH links when the --no-user-env (or similar) is available
-# See https://github.com/jupyterhub/the-littlest-jupyterhub/pull/528
-tljh_bootstrap_pip_spec: git+https://github.com/jtpio/the-littlest-jupyterhub.git@skip-install#"egg=the_littlest_jupyterhub"
-tljh_installer_url: https://raw.githubusercontent.com/jtpio/the-littlest-jupyterhub/skip-install/bootstrap/bootstrap.py
+tljh_installer_url: https://tljh.jupyter.org/bootstrap.py
 
 ...

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub@2.0.0
-tljh-repo2docker>=2.0,<3
+tljh-repo2docker>=3.0.0a0,<4
 jupyterhub>=5,<6
 notebook
 pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,10 @@
-git+https://github.com/jupyterhub/the-littlest-jupyterhub
+git+https://github.com/jupyterhub/the-littlest-jupyterhub@1.0.0
 tljh-repo2docker>=2.1,<3
-jupyterhub~=1.5
-notebook<7
+jupyterhub>=4,<5
+notebook
 pytest
 pytest-aiohttp
 pytest-asyncio
 pytest-cov
+pytest-jupyterhub
 requests-mock

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
-git+https://github.com/jupyterhub/the-littlest-jupyterhub@1.0.0
+git+https://github.com/jupyterhub/the-littlest-jupyterhub@2.0.0
 tljh-repo2docker>=2.1,<3
-jupyterhub>=4,<5
+jupyterhub>=5,<6
 notebook
 pytest
 pytest-aiohttp

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub@2.0.0
-tljh-repo2docker>=2.1,<3
+tljh-repo2docker>=2.0,<3
 jupyterhub>=5,<6
 notebook
 pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub
-tljh-repo2docker<2
+tljh-repo2docker>=2.1,<3
 jupyterhub~=1.5
 notebook<7
 pytest

--- a/docs/install/ansible.md
+++ b/docs/install/ansible.md
@@ -268,6 +268,21 @@ tagged as `v0.1`:
 tljh_plasma: git+https://github.com/plasmabio/plasma@v0.1#"egg=tljh-plasma&subdirectory=tljh-plasma"
 ```
 
+## Using a specific version of `repo2docker`
+
+`repo2docker` is used to build the user environments from the Git repositories.
+
+By default the Ansible playbooks use a pinned version of the `jupyterhub/repo2docker`, which is defined in the
+`ansible/vars/default.yml` file.
+
+Like other Ansible variables, it is possible to use a different version of `repo2docker` by overriding the variable
+via the command line:
+
+```bash
+# use an older version of the repo2docker image
+ansible-playbook tljh.yml -i hosts -u ubuntu -e "repo2docker_docker_tag=2022.10.0-232.g0ea6f7d"
+```
+
 ## List of available playbooks
 
 The Ansible playbooks are located in the `ansible/` directory:

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -5,17 +5,23 @@ and overrides some of the default values from the plugin.
 
 import getpass
 import os
+import sys
 
 from tljh_plasma import tljh_custom_jupyterhub_config
 from tljh_repo2docker import (
+    TLJH_R2D_ADMIN_SCOPE,
     tljh_custom_jupyterhub_config as tljh_repo2docker_config_hook,
 )
+
+# Configure JupyterHub to bind to localhost to avoid hostname resolution issues
+c.JupyterHub.ip = '127.0.0.1'
+c.JupyterHub.port = 8000
 
 c.JupyterHub.services = []
 
 # tljh-plasma depends on tljh-repo2docker
 tljh_repo2docker_config_hook(c)
-tljh_custom_jupyterhub_config(c, 'config.yaml')
+tljh_custom_jupyterhub_config(c, "config.yaml")
 
 user = getpass.getuser()
 
@@ -24,3 +30,40 @@ c.Authenticator.admin_users = {user}
 # configure the volumes paths for local setup
 c.PlasmaSpawner.base_volume_path = os.path.join(os.getcwd(), "volumes/user")
 c.PlasmaSpawner.shared_data_path = os.path.join(os.getcwd(), "volumes/data")
+
+c.JupyterHub.services.extend(
+    [
+        {
+            "name": "tljh_repo2docker",
+            "url": "http://127.0.0.1:6789",
+            "command": [
+                sys.executable,
+                "-m",
+                "tljh_repo2docker",
+                "--ip",
+                "127.0.0.1",
+                "--port",
+                "6789",
+            ],
+            "oauth_no_confirm": True,
+            "oauth_client_allowed_scopes": [
+                TLJH_R2D_ADMIN_SCOPE,
+            ],
+        }
+    ]
+)
+
+c.JupyterHub.custom_scopes = {
+    TLJH_R2D_ADMIN_SCOPE: {
+        "description": "Admin access to tljh_repo2docker",
+    },
+}
+
+c.JupyterHub.load_roles = [
+    {
+        "name": "tljh-repo2docker-service-admin",
+        "users": [user],
+        "scopes": [TLJH_R2D_ADMIN_SCOPE],
+    },
+]
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 python_files = test_*.py
+asyncio_mode = auto

--- a/tljh-plasma/setup.py
+++ b/tljh-plasma/setup.py
@@ -6,5 +6,5 @@ setup(
     entry_points={"tljh": ["tljh_plasma = tljh_plasma"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["dockerspawner>=14,<15", "tljh_repo2docker>=3.0.0a0,<4", "sqlalchemy<2"],
+    install_requires=["dockerspawner>=14,<15", "tljh_repo2docker>=3.0.0a0,<4", "sqlalchemy>=2"],
 )

--- a/tljh-plasma/setup.py
+++ b/tljh-plasma/setup.py
@@ -6,5 +6,5 @@ setup(
     entry_points={"tljh": ["tljh_plasma = tljh_plasma"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["dockerspawner~=12.1", "tljh_repo2docker", "sqlalchemy<2"],
+    install_requires=["dockerspawner>=14,<15", "tljh_repo2docker>=3.0.0a0,<4", "sqlalchemy<2"],
 )

--- a/tljh-plasma/tljh_plasma/__init__.py
+++ b/tljh-plasma/tljh_plasma/__init__.py
@@ -123,6 +123,8 @@ def tljh_custom_jupyterhub_config(c, tljh_config_file=CONFIG_FILE):
     c.PlasmaSpawner.cmd = ["/srv/conda/envs/notebook/bin/jupyterhub-singleuser"]
     # set the default cpu and memory limits
     c.PlasmaSpawner.args = ["--ResourceUseDisplay.track_cpu_percent=True"]
+    # explicitely opt-in to enable the custom entrypoint logic
+    c.PlasmaSpawner.run_as_root = True
 
     # prevent PID 1 running in the Docker container to stop when child processes are killed
     # see https://github.com/plasmabio/plasma/issues/191 for more info

--- a/tljh-plasma/tljh_plasma/__init__.py
+++ b/tljh-plasma/tljh_plasma/__init__.py
@@ -1,5 +1,6 @@
 import grp
 import os
+import platform
 import pwd
 
 from dockerspawner import SystemUserSpawner
@@ -128,10 +129,13 @@ def tljh_custom_jupyterhub_config(c, tljh_config_file=CONFIG_FILE):
 
     # prevent PID 1 running in the Docker container to stop when child processes are killed
     # see https://github.com/plasmabio/plasma/issues/191 for more info
-    c.PlasmaSpawner.extra_host_config = {'init': True}
+    c.PlasmaSpawner.extra_host_config = {"init": True}
 
     # register Cockpit as a service if active
-    if check_service_active("cockpit"):
+    if platform.system() == "Linux" and check_service_active("cockpit"):
         c.JupyterHub.services.append(
-            {"name": "cockpit", "url": "http://0.0.0.0:9090",},
+            {
+                "name": "cockpit",
+                "url": "http://0.0.0.0:9090",
+            },
         )

--- a/tljh-plasma/tljh_plasma/__init__.py
+++ b/tljh-plasma/tljh_plasma/__init__.py
@@ -84,6 +84,7 @@ def tljh_custom_jupyterhub_config(c, tljh_config_file=CONFIG_FILE):
     # hub
     c.JupyterHub.cleanup_servers = False
     c.JupyterHub.authenticator_class = PAMAuthenticator
+    c.Authenticator.allow_all = True
     c.JupyterHub.spawner_class = PlasmaSpawner
     c.JupyterHub.template_paths.insert(
         0, os.path.join(os.path.dirname(__file__), "templates")

--- a/tljh-plasma/tljh_plasma/entrypoint/entrypoint.sh
+++ b/tljh-plasma/tljh_plasma/entrypoint/entrypoint.sh
@@ -43,4 +43,4 @@ export JUPYTER_PATH=${IMAGE_DIR}/.local/share/jupyter
 cd ${IMAGE_DIR}
 
 # execute the notebook process as the given user
-exec su - $NB_USER -m -c '"$0" "$@"' -- "$@"
+exec su $NB_USER -m -c '"$0" "$@"' -- "$@"

--- a/tljh-plasma/tljh_plasma/permissions.py
+++ b/tljh-plasma/tljh_plasma/permissions.py
@@ -7,7 +7,7 @@ from inspect import isawaitable
 from jupyterhub.apihandlers import APIHandler
 from jupyterhub.handlers.base import BaseHandler
 from jupyterhub.orm import Base, Column, Integer, Unicode
-from jupyterhub.utils import admin_only
+from jupyterhub.scopes import needs_scope
 from tljh_repo2docker.docker import list_images
 from tornado.web import authenticated
 
@@ -32,7 +32,7 @@ class PermissionsHandler(BaseHandler):
     """
 
     @authenticated
-    @admin_only
+    @needs_scope("admin-ui")
     async def get(self):
         include_groups = self.settings.get("include_groups")
         all_groups = list_groups(include_groups)
@@ -60,8 +60,8 @@ class PermissionsAPIHandler(APIHandler):
     Handle edits to the mapping of environments and groups.
     """
 
-    @admin_only
     @authenticated
+    @needs_scope("admin-ui")
     async def post(self):
         raw_args = self.request.body.decode("utf-8")
         args = json.loads(raw_args)

--- a/tljh-plasma/tljh_plasma/tests/conftest.py
+++ b/tljh-plasma/tljh_plasma/tests/conftest.py
@@ -1,16 +1,12 @@
-import asyncio
-import os
-import sys
-
 import pytest
 
+from jupyterhub.tests.mocking import MockPAMAuthenticator
 from tljh_repo2docker.tests.conftest import (
     minimal_repo,
     image_name,
     generated_image_name,
     remove_all_test_images
 )
-from tljh_repo2docker.tests.utils import add_environment
 from tljh_repo2docker import tljh_custom_jupyterhub_config as tljh_repo2docker_config
 from tljh_plasma import tljh_custom_jupyterhub_config as tljh_plasma_config
 from traitlets.config import Config
@@ -19,10 +15,11 @@ from traitlets.config import Config
 @pytest.fixture
 async def app(hub_app):
     config = Config()
-    config.authenticator_class = 'jupyterhub.tests.mocking.MockPAMAuthenticator'
 
     tljh_repo2docker_config(config)
     tljh_plasma_config(config)
+
+    config.JupyterHub.authenticator_class = MockPAMAuthenticator
 
     app = await hub_app(config=config)
     return app

--- a/tljh-plasma/tljh_plasma/tests/conftest.py
+++ b/tljh-plasma/tljh_plasma/tests/conftest.py
@@ -1,12 +1,11 @@
 import pytest
 
 from jupyterhub.tests.mocking import MockPAMAuthenticator
-from tljh_repo2docker.tests.conftest import (
-    minimal_repo,
+from tljh_repo2docker.tests.local_build.conftest import (
     image_name,
     generated_image_name,
-    remove_all_test_images
 )
+from tljh_repo2docker.tests.conftest import minimal_repo, remove_all_test_images
 from tljh_repo2docker import tljh_custom_jupyterhub_config as tljh_repo2docker_config
 from tljh_plasma import tljh_custom_jupyterhub_config as tljh_plasma_config
 from traitlets.config import Config

--- a/tljh-plasma/tljh_plasma/tests/conftest.py
+++ b/tljh-plasma/tljh_plasma/tests/conftest.py
@@ -1,17 +1,10 @@
 import asyncio
+import os
 import sys
 
 import pytest
 
-from jupyterhub.tests.conftest import (
-    io_loop,
-    event_loop,
-    db,
-    pytest_collection_modifyitems,
-)
-from jupyterhub.tests.mocking import MockHub, MockPAMAuthenticator
 from tljh_repo2docker.tests.conftest import (
-    DummyConfig,
     minimal_repo,
     image_name,
     generated_image_name,
@@ -20,40 +13,16 @@ from tljh_repo2docker.tests.conftest import (
 from tljh_repo2docker.tests.utils import add_environment
 from tljh_repo2docker import tljh_custom_jupyterhub_config as tljh_repo2docker_config
 from tljh_plasma import tljh_custom_jupyterhub_config as tljh_plasma_config
+from traitlets.config import Config
 
 
-@pytest.fixture(scope="module")
-def app(request, io_loop):
-    """
-    Adapted from:
-    https://github.com/jupyterhub/jupyterhub/blob/8a3790b01ff944c453ffcc0486149e2a58ffabea/jupyterhub/tests/conftest.py#L74
-    """
+@pytest.fixture
+async def app(hub_app):
+    config = Config()
+    config.authenticator_class = 'jupyterhub.tests.mocking.MockPAMAuthenticator'
 
-    # create a JupyterHub mock instance
-    mocked_app = MockHub.instance()
-    c = DummyConfig()
-    c.JupyterHub = mocked_app
+    tljh_repo2docker_config(config)
+    tljh_plasma_config(config)
 
-    # apply the config from the plugins
-    tljh_repo2docker_config(c)
-    tljh_plasma_config(c)
-
-    # switch back to the MockPAMAuthenticator for the tests
-    c.JupyterHub.authenticator_class = MockPAMAuthenticator
-
-    async def make_app():
-        await mocked_app.initialize([])
-        await mocked_app.start()
-
-    def fin():
-        # disconnect logging during cleanup because pytest closes captured FDs prematurely
-        mocked_app.log.handlers = []
-        MockHub.clear_instance()
-        try:
-            mocked_app.stop()
-        except Exception as e:
-            print("Error stopping Hub: %s" % e, file=sys.stderr)
-
-    request.addfinalizer(fin)
-    io_loop.run_sync(make_app)
-    return mocked_app
+    app = await hub_app(config=config)
+    return app


### PR DESCRIPTION
Fixes #216 

Trying to test https://github.com/plasmabio/plasma/pull/217 on a VM was leading to issues installing the Python requirements from the custom branch. However using the default installer together with #217 seems to be working well.

For reference we were still pointing to a branch of my TLJH fork which had a floag to not create a base user environment since Plasma uses Docker: https://github.com/jupyterhub/the-littlest-jupyterhub/pull/528
However this upstream PR has been closed and there is no ongoing work to re-add a similar feature at the moment.

That said this PR was initially raised because creating the default environment used to be taking a very long time when it was still installing JupyterLab 2 and building it with extensions. Now TLJH has switch to JupyterLab 3+ and mamba, and creating the default environment is much faster now.

- [x] Update to a pinned version of the TLJH installer (v1): https://tljh.jupyter.org/en/latest/howto/admin/upgrade-tljh.html#step-3-make-the-upgrade
- [ ] Documentation

---

Also bring the changes from #217 :

Update the `jupyterhub/repo2docker` Docker image to point to a pinned version by default.

The tag is made configurable in case so it's easier to override if needed, without having to update this repo.

Having a default pinned version makes it easier to reason about which version is being installed when the playbook is run multiple times.

Fixes https://github.com/plasmabio/plasma/issues/211

- [x] Pick the latest stable tag as default: `2023.06.0-41.g57d229e`
- [x] Add / update the documentation: https://plasmabio--224.org.readthedocs.build/en/224/
- [x] Fix custom entrypoint with the newer `repo2docker`
- [x] Fix tests